### PR TITLE
[Feat] #121 token

### DIFF
--- a/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoViewModel.kt
@@ -35,6 +35,9 @@ class CafeInfoViewModel @Inject constructor(
     val listReviewData: LiveData<Resource<CafeReviews>>
         get() = _listReviewData
 
+    private val _signInStateFlow = MutableStateFlow(false)
+    val signInStateFlow = _signInStateFlow.asStateFlow()
+
     fun initViewModel(cafe: Cafe, isFavorite: Boolean) {
         this.cafe = cafe
         this._isFavoriteCafe.value = isFavorite
@@ -86,6 +89,12 @@ class CafeInfoViewModel @Inject constructor(
                 cafeRepository.localDeleteFavoriteCafe(currentCafe)
             }
             _isFavoriteCafe.value = false
+        }
+    }
+
+    fun updateSignInState() {
+        viewModelScope.launch {
+            _signInStateFlow.value = userRepository.isLoggedIn().first()
         }
     }
 

--- a/app/src/main/java/org/cazait/ui/component/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -1,7 +1,7 @@
 package org.cazait.ui.component.cafeinfo.detail
 
+import android.app.AlertDialog
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -29,6 +29,11 @@ class CafeInfoReviewFragment(
     private lateinit var binding: FragmentCafeInfoReviewBinding
     private lateinit var reviewAdapter: CafeInfoReviewAdapter
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.updateSignInState()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -44,9 +49,18 @@ class CafeInfoReviewFragment(
         initAdapter()
         observeViewModel()
         binding.fabEditReview.setOnClickListener {
-            // TODO 여기서 만일 로그인하지 않았다면 "로그인이 필요한 서비스입니다"를 사용자에게 보여준다.
-            val intent = ReviewEditActivity.reviewIntent(requireContext(), cafe)
-            startActivity(intent)
+            val isLoggedIn = viewModel.signInStateFlow.value
+            if (isLoggedIn) {
+                val intent = ReviewEditActivity.reviewIntent(requireContext(), cafe)
+                startActivity(intent)
+            } else {
+                AlertDialog.Builder(requireContext())
+                    .setMessage(resources.getString(R.string.need_login))
+                    .setPositiveButton("확인") { dialog, which ->
+                        dialog.dismiss()
+                    }
+                    .show()
+            }
         }
     }
 

--- a/app/src/main/java/org/cazait/ui/component/review/ReviewEditViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/review/ReviewEditViewModel.kt
@@ -35,7 +35,7 @@ class ReviewEditViewModel @Inject constructor(
             val content = reviewContentLiveData.value ?: return@launch
 
             Log.d("ReviewEditViewModel", "$userId, $score, $content")
-            cafeRepository.postReview(userId, cafeId, score.toInt(), content).first()
+            cafeRepository.postReviewAuth(userId, cafeId, score.toInt(), content).first()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="info_review">리뷰쓰기</string>
     <string name="no_menu">아직 준비된 메뉴가 없어요..😢</string>
     <string name="no_review">아직 등록된 리뷰가 없어요..ㅠ\n❤️리뷰 등록해줘잉❤️</string>
+    <string name="need_login">로그인이 필요한 서비스입니다.</string>
 
     <!-- Item Cafe Menu -->
     <string name="menu_name">아메리카노</string>

--- a/core/data/src/main/java/org/bmsk/data/repository/CafeRepository.kt
+++ b/core/data/src/main/java/org/bmsk/data/repository/CafeRepository.kt
@@ -30,7 +30,7 @@ interface CafeRepository {
         lastId: Long?
     ): Flow<Resource<CafeReviews>>
 
-    suspend fun postReview(
+    suspend fun postReviewAuth(
         userId: Long,
         cafeId: Long,
         score: Int,

--- a/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
+++ b/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
@@ -146,14 +146,14 @@ class CafeRepositoryImpl @Inject constructor(
         }.flowOn(ioDispatcher)
     }
 
-    override suspend fun postReview(
+    override suspend fun postReviewAuth(
         userId: Long,
         cafeId: Long,
         score: Int,
         content: String
     ): Flow<Resource<String>> {
         return flow {
-            when (val response = cafeInfoRemoteData.postReview(userId, cafeId, score, content)) {
+            when (val response = cafeInfoRemoteData.postReviewAuth(userId, cafeId, score, content)) {
                 is DataResponse.Success -> {
                     val message: String =
                         response.data?.message ?: ""

--- a/core/datastore/src/main/java/org/cazait/datastore/data/repository/UserPreferenceRepository.kt
+++ b/core/datastore/src/main/java/org/cazait/datastore/data/repository/UserPreferenceRepository.kt
@@ -1,6 +1,7 @@
 package org.cazait.datastore.data.repository
 
 import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.first
 import org.cazait.model.local.UserPreference
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -10,6 +11,14 @@ class UserPreferenceRepository @Inject constructor(
     private val userPreferenceDataSource: DataStore<UserPreference>
 ) {
     fun getUserPreference() = userPreferenceDataSource.data
+
+    suspend fun getAccessToken(): String {
+        return getUserPreference().first().accessToken
+    }
+
+    suspend fun getRefreshToken(): String {
+        return getUserPreference().first().refreshToken
+    }
 
     suspend fun updateUserPreference(
         isLoggedIn: Boolean,

--- a/core/network/build.gradle
+++ b/core/network/build.gradle
@@ -35,12 +35,14 @@ android {
 }
 
 dependencies {
+    implementation project(path: ':core:model')
+    implementation project(path: ':core:datastore')
+
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
 
     // Hilt Library
     implementation("com.google.dagger:hilt-android:$hiltVersion")
-    implementation project(path: ':core:model')
     kapt("com.google.dagger:hilt-android-compiler:$hiltVersion")
     kapt("androidx.hilt:hilt-compiler:$hiltCompilerVersion")
 

--- a/core/network/src/main/java/org/cazait/network/api/AuthedService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/AuthedService.kt
@@ -1,0 +1,17 @@
+package org.cazait.network.api
+
+import org.cazait.network.model.dto.request.CafeReviewPostReq
+import org.cazait.network.model.dto.response.CafeReviewPostRes
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface AuthedService {
+    @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
+    suspend fun postReviewAuth(
+        @Path("userId") userId: Long,
+        @Path("cafeId") cafeId: Long,
+        @Body reviewPostReq: CafeReviewPostReq,
+    ): Response<CafeReviewPostRes>
+}

--- a/core/network/src/main/java/org/cazait/network/api/CafeService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/CafeService.kt
@@ -81,7 +81,7 @@ interface CafeService {
     ): Response<DeleteFavoriteCafeRes>
 
     @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
-    suspend fun postReview(
+    suspend fun postReviewAuth(
         @Path("userId") userId: Long,
         @Path("cafeId") cafeId: Long,
         @Body reviewPostReq: CafeReviewPostReq,

--- a/core/network/src/main/java/org/cazait/network/api/CafeService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/CafeService.kt
@@ -80,12 +80,12 @@ interface CafeService {
         @Path("cafeId") cafeId: Long,
     ): Response<DeleteFavoriteCafeRes>
 
-    @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
-    suspend fun postReviewAuth(
-        @Path("userId") userId: Long,
-        @Path("cafeId") cafeId: Long,
-        @Body reviewPostReq: CafeReviewPostReq,
-    ): Response<CafeReviewPostRes>
+//    @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
+//    suspend fun postReviewAuth(
+//        @Path("userId") userId: Long,
+//        @Path("cafeId") cafeId: Long,
+//        @Body reviewPostReq: CafeReviewPostReq,
+//    ): Response<CafeReviewPostRes>
 
     @GET("/api/cafes/name/{cafeName}")
     suspend fun getCafeSearch(

--- a/core/network/src/main/java/org/cazait/network/api/auth/AuthedService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/auth/AuthedService.kt
@@ -1,4 +1,4 @@
-package org.cazait.network.api
+package org.cazait.network.api.auth
 
 import org.cazait.network.model.dto.request.CafeReviewPostReq
 import org.cazait.network.model.dto.response.CafeReviewPostRes

--- a/core/network/src/main/java/org/cazait/network/api/unauth/AuthService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/unauth/AuthService.kt
@@ -1,4 +1,4 @@
-package org.cazait.network.api
+package org.cazait.network.api.unauth
 
 import org.cazait.network.model.dto.request.SignInReq
 import org.cazait.network.model.dto.response.RefreshTokenRes

--- a/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
@@ -1,4 +1,4 @@
-package org.cazait.network.api
+package org.cazait.network.api.unauth
 
 import org.cazait.network.model.dto.request.CafeReviewPostReq
 import org.cazait.network.model.dto.response.CafeId

--- a/core/network/src/main/java/org/cazait/network/api/unauth/UserService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/unauth/UserService.kt
@@ -1,4 +1,4 @@
-package org.cazait.network.api
+package org.cazait.network.api.unauth
 
 import org.cazait.network.model.dto.request.IsNicknameDupReq
 import org.cazait.network.model.dto.request.SignUpReq

--- a/core/network/src/main/java/org/cazait/network/datasource/AuthRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/AuthRemoteData.kt
@@ -2,7 +2,7 @@ package org.cazait.network.datasource
 
 import android.util.Log
 import org.cazait.network.NetworkConnectivity
-import org.cazait.network.api.AuthService
+import org.cazait.network.api.unauth.AuthService
 import org.cazait.network.error.NETWORK_ERROR
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.request.SignInReq

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
@@ -2,15 +2,12 @@ package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
 import org.cazait.network.api.CafeService
+import org.cazait.network.api.AuthedService
 import org.cazait.network.di.Authenticated
-import org.cazait.network.di.Unauthenticated
 import org.cazait.network.error.NETWORK_ERROR
-import org.cazait.network.error.NO_INTERNET_CONNECTION
-import org.cazait.network.model.dto.CafeDTO
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.request.CafeReviewPostReq
 import org.cazait.network.model.dto.response.CafeMenuRes
-import org.cazait.network.model.dto.response.CafeRes
 import org.cazait.network.model.dto.response.CafeResTemp
 import org.cazait.network.model.dto.response.CafeReviewPostRes
 import org.cazait.network.model.dto.response.CafeReviewRes
@@ -21,12 +18,12 @@ import java.io.IOException
 import javax.inject.Inject
 
 class CafeInfoRemoteData @Inject constructor(
-    @Unauthenticated private val cafeService: CafeService,
-    @Authenticated private val cafeServiceAuth: CafeService,
+    private val cafeService: CafeService,
+    @Authenticated private val cafeServiceAuth: AuthedService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeInfoRemoteDataSource {
     override suspend fun getCafe(cafeId: Long): DataResponse<CafeResTemp> {
-        return when(val response = processCall {
+        return when (val response = processCall {
             cafeService.getCafe(cafeId)
         }) {
             is CafeResTemp -> {
@@ -82,13 +79,14 @@ class CafeInfoRemoteData @Inject constructor(
         score: Int,
         content: String
     ): DataResponse<CafeReviewPostRes> {
-        return when(val response = processCall {
+        return when (val response = processCall {
             val req = CafeReviewPostReq(score, content)
             cafeServiceAuth.postReviewAuth(userId, cafeId, req)
         }) {
             is CafeReviewPostRes -> {
                 DataResponse.Success(data = response)
             }
+
             else -> {
                 DataResponse.DataError(errorCode = response as Int)
             }

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
@@ -2,6 +2,8 @@ package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
 import org.cazait.network.api.CafeService
+import org.cazait.network.di.Authenticated
+import org.cazait.network.di.Unauthenticated
 import org.cazait.network.error.NETWORK_ERROR
 import org.cazait.network.error.NO_INTERNET_CONNECTION
 import org.cazait.network.model.dto.CafeDTO
@@ -19,7 +21,8 @@ import java.io.IOException
 import javax.inject.Inject
 
 class CafeInfoRemoteData @Inject constructor(
-    private val cafeService: CafeService,
+    @Unauthenticated private val cafeService: CafeService,
+    @Authenticated private val cafeServiceAuth: CafeService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeInfoRemoteDataSource {
     override suspend fun getCafe(cafeId: Long): DataResponse<CafeResTemp> {
@@ -73,7 +76,7 @@ class CafeInfoRemoteData @Inject constructor(
         }
     }
 
-    override suspend fun postReview(
+    override suspend fun postReviewAuth(
         userId: Long,
         cafeId: Long,
         score: Int,
@@ -81,7 +84,7 @@ class CafeInfoRemoteData @Inject constructor(
     ): DataResponse<CafeReviewPostRes> {
         return when(val response = processCall {
             val req = CafeReviewPostReq(score, content)
-            cafeService.postReview(userId, cafeId, req)
+            cafeServiceAuth.postReviewAuth(userId, cafeId, req)
         }) {
             is CafeReviewPostRes -> {
                 DataResponse.Success(data = response)

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
@@ -1,8 +1,8 @@
 package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
-import org.cazait.network.api.CafeService
-import org.cazait.network.api.AuthedService
+import org.cazait.network.api.unauth.CafeService
+import org.cazait.network.api.auth.AuthedService
 import org.cazait.network.di.Authenticated
 import org.cazait.network.error.NETWORK_ERROR
 import org.cazait.network.model.dto.DataResponse

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteDataSource.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteDataSource.kt
@@ -1,9 +1,7 @@
 package org.cazait.network.datasource
 
-import org.cazait.network.model.dto.CafeDTO
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.response.CafeMenuRes
-import org.cazait.network.model.dto.response.CafeRes
 import org.cazait.network.model.dto.response.CafeResTemp
 import org.cazait.network.model.dto.response.CafeReviewPostRes
 import org.cazait.network.model.dto.response.CafeReviewRes
@@ -21,7 +19,7 @@ interface CafeInfoRemoteDataSource {
         lastId: Long?
     ): DataResponse<CafeReviewRes>
 
-    suspend fun postReview(
+    suspend fun postReviewAuth(
         userId: Long,
         cafeId: Long,
         score: Int,

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
@@ -1,9 +1,8 @@
 package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
-import org.cazait.network.api.CafeService
+import org.cazait.network.api.unauth.CafeService
 import org.cazait.network.error.NETWORK_ERROR
-import org.cazait.network.error.NO_INTERNET_CONNECTION
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.request.ListCafesReq
 import org.cazait.network.model.dto.response.ListCafesRes

--- a/core/network/src/main/java/org/cazait/network/datasource/UserRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/UserRemoteData.kt
@@ -9,8 +9,7 @@ import org.cazait.network.model.dto.response.IsNicknameDupRes
 import org.cazait.network.model.dto.response.SignUpRes
 import org.cazait.network.NetworkConnectivity
 import org.cazait.network.error.NETWORK_ERROR
-import org.cazait.network.error.NO_INTERNET_CONNECTION
-import org.cazait.network.api.UserService
+import org.cazait.network.api.unauth.UserService
 import retrofit2.Response
 import java.io.IOException
 import javax.inject.Inject

--- a/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
@@ -7,15 +7,26 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.cazait.datastore.data.repository.UserPreferenceRepository
 import org.cazait.network.Network
 import org.cazait.network.NetworkConnectivity
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Authenticated
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Unauthenticated
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -49,6 +60,7 @@ object RetrofitModule {
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesHeaderInterceptor(): Interceptor {
         return Interceptor { chain ->
             val original = chain.request()
@@ -63,6 +75,7 @@ object RetrofitModule {
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesOkHttpClient(
         logger: HttpLoggingInterceptor,
         headerInterceptor: Interceptor,
@@ -78,7 +91,63 @@ object RetrofitModule {
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesRetrofit(
+        client: OkHttpClient.Builder,
+        gsonConverterFactory: GsonConverterFactory,
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client.build())
+            .addConverterFactory(gsonConverterFactory)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesHeaderInterceptorAuth(userPreferenceRepository: UserPreferenceRepository): Interceptor {
+        return Interceptor { chain ->
+            var accessToken: String
+            var refreshToken: String
+
+            runBlocking {
+                accessToken = userPreferenceRepository.getAccessToken()
+                refreshToken = userPreferenceRepository.getRefreshToken()
+            }
+
+            val original = chain.request()
+            val request = original.newBuilder()
+                .header(CONTENT_TYPE, CONTENT_TYPE_VALUE)
+                .header("Authorization", "Bearer $accessToken")
+                .header("refreshToken", refreshToken)
+                .method(original.method, original.body)
+                .build()
+
+            chain.proceed(request)
+        }
+    }
+
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesOkHttpClientAuth(
+        logger: HttpLoggingInterceptor,
+        headerInterceptor: Interceptor,
+    ): OkHttpClient.Builder {
+        return OkHttpClient.Builder().apply {
+            addInterceptor(headerInterceptor)
+            addInterceptor(logger)
+            connectTimeout(TIMEOUT_CONNECT, TimeUnit.SECONDS)
+            readTimeout(TIMEOUT_READ, TimeUnit.SECONDS)
+            writeTimeout(TIMEOUT_WRITE, TimeUnit.SECONDS)
+        }
+    }
+
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesRetrofitAuth(
         client: OkHttpClient.Builder,
         gsonConverterFactory: GsonConverterFactory,
     ): Retrofit {

--- a/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
@@ -24,10 +24,6 @@ import javax.inject.Singleton
 @Retention(AnnotationRetention.BINARY)
 annotation class Authenticated
 
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class Unauthenticated
-
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
@@ -60,7 +56,6 @@ object RetrofitModule {
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesHeaderInterceptor(): Interceptor {
         return Interceptor { chain ->
             val original = chain.request()
@@ -75,7 +70,6 @@ object RetrofitModule {
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesOkHttpClient(
         logger: HttpLoggingInterceptor,
         headerInterceptor: Interceptor,
@@ -91,7 +85,6 @@ object RetrofitModule {
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesRetrofit(
         client: OkHttpClient.Builder,
         gsonConverterFactory: GsonConverterFactory,

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -16,25 +16,55 @@ object ServiceModule {
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesCafeService(
-        retrofit: Retrofit
+        @Unauthenticated retrofit: Retrofit
     ): CafeService {
         return retrofit.create(CafeService::class.java)
     }
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesUserService(
-        retrofit: Retrofit
+        @Unauthenticated retrofit: Retrofit
     ): UserService {
         return retrofit.create(UserService::class.java)
     }
 
     @Provides
     @Singleton
+    @Unauthenticated
     fun providesAuthService(
-        retrofit: Retrofit
+        @Unauthenticated retrofit: Retrofit
     ): AuthService {
         return retrofit.create(AuthService::class.java)
     }
+
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesCafeServiceAuth(
+        @Authenticated retrofit: Retrofit
+    ): CafeService {
+        return retrofit.create(CafeService::class.java)
+    }
+
+//    @Provides
+//    @Singleton
+//    @Authenticated
+//    fun providesUserServiceAuth(
+//        @Authenticated retrofit: Retrofit
+//    ): UserService {
+//        return retrofit.create(UserService::class.java)
+//    }
+//
+//    @Provides
+//    @Singleton
+//    @Authenticated
+//    fun providesAuthServiceAuth(
+//        @Authenticated retrofit: Retrofit
+//    ): AuthService {
+//        return retrofit.create(AuthService::class.java)
+//    }
 }

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -4,10 +4,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.cazait.network.api.AuthService
-import org.cazait.network.api.AuthedService
-import org.cazait.network.api.CafeService
-import org.cazait.network.api.UserService
+import org.cazait.network.api.unauth.AuthService
+import org.cazait.network.api.auth.AuthedService
+import org.cazait.network.api.unauth.CafeService
+import org.cazait.network.api.unauth.UserService
 import retrofit2.Retrofit
 import javax.inject.Singleton
 

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.cazait.network.api.AuthService
+import org.cazait.network.api.AuthedService
 import org.cazait.network.api.CafeService
 import org.cazait.network.api.UserService
 import retrofit2.Retrofit
@@ -16,27 +17,24 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesCafeService(
-        @Unauthenticated retrofit: Retrofit
+        retrofit: Retrofit
     ): CafeService {
         return retrofit.create(CafeService::class.java)
     }
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesUserService(
-        @Unauthenticated retrofit: Retrofit
+        retrofit: Retrofit
     ): UserService {
         return retrofit.create(UserService::class.java)
     }
 
     @Provides
     @Singleton
-    @Unauthenticated
     fun providesAuthService(
-        @Unauthenticated retrofit: Retrofit
+        retrofit: Retrofit
     ): AuthService {
         return retrofit.create(AuthService::class.java)
     }
@@ -46,8 +44,8 @@ object ServiceModule {
     @Authenticated
     fun providesCafeServiceAuth(
         @Authenticated retrofit: Retrofit
-    ): CafeService {
-        return retrofit.create(CafeService::class.java)
+    ): AuthedService {
+        return retrofit.create(AuthedService::class.java)
     }
 
 //    @Provides

--- a/core/network/src/test/java/org/bmsk/network/UserRemoteDataTest.kt
+++ b/core/network/src/test/java/org/bmsk/network/UserRemoteDataTest.kt
@@ -2,7 +2,7 @@ package org.bmsk.network
 
 import kotlinx.coroutines.runBlocking
 import org.cazait.network.NetworkConnectivity
-import org.cazait.network.api.UserService
+import org.cazait.network.api.unauth.UserService
 import org.cazait.network.datasource.UserRemoteData
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.request.IsEmailDupReq


### PR DESCRIPTION
## 토큰인증이 필요한 경우와 불필요한 경우에 대한 토큰 작업
- RetrofitModule에 헤더에 토큰이 필요한 경우의 Interceptor와 client, retrofit 객체 새로 생성
- Anotation은 @Authenticated만 생성. @Unathenticated 도 생성할 경우 둘 다 아닌경우의 예외처리가 필요함..(복잡..)
- org.cazait.network.api에서 토큰인증이 필요한 경우와 불필요한 경우의 패키지 구분(api.auth, api.unauth)
- 기존 api는 unauth에 넣었고 현재 auth에는 postReview만 있음.
- 로그인이 안된 상태에서 리뷰 작성하기 버튼을 누르면 로그인 상태를 확인하고 '로그인이 필요한 서비스입니다.' dialog 생성.