### PR TITLE
[Refact]#124-바텀네비게이션 마이페이지 탭 Fragment 초기화

### DIFF
--- a/app/src/main/java/org/cazait/ui/component/MainActivity.kt
+++ b/app/src/main/java/org/cazait/ui/component/MainActivity.kt
@@ -3,6 +3,7 @@ package org.cazait.ui.component
 import android.os.Bundle
 import android.view.View
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
@@ -10,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.cazait.R
 import org.cazait.databinding.ActivityMainBinding
 import org.cazait.ui.base.BaseActivity
+import org.cazait.ui.component.mypage.MyPageFragment
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>(
@@ -35,10 +37,9 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainViewModel>(
             supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         binding.bnvMenu.setupWithNavController(navHostFragment.navController)
         navHostFragment.navController.addOnDestinationChangedListener { _, destination, _ ->
-            if(destination.id == R.id.signInFragment || destination.id == R.id.signupFragment || destination.id == R.id.recentlyCafeFragment){
+            if (destination.id == R.id.signInFragment || destination.id == R.id.signupFragment) {
                 binding.bnvMenu.visibility = View.GONE
-            }
-            else{
+            } else {
                 binding.bnvMenu.visibility = View.VISIBLE
             }
         }

--- a/app/src/main/java/org/cazait/ui/component/recentlycafe/RecentlyCafeFragment.kt
+++ b/app/src/main/java/org/cazait/ui/component/recentlycafe/RecentlyCafeFragment.kt
@@ -32,11 +32,6 @@ class RecentlyCafeFragment : BaseFragment<FragmentRecentlyCafeBinding, RecentlyC
         viewModel.fetchRecentlyViewedCafes()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d("RecentlyCafeFragment", "onDestroy called")
-    }
-
     override fun initAfterBinding() {
 
     }

--- a/app/src/main/java/org/cazait/ui/component/recentlycafe/RecentlyCafeFragment.kt
+++ b/app/src/main/java/org/cazait/ui/component/recentlycafe/RecentlyCafeFragment.kt
@@ -32,6 +32,11 @@ class RecentlyCafeFragment : BaseFragment<FragmentRecentlyCafeBinding, RecentlyC
         viewModel.fetchRecentlyViewedCafes()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("RecentlyCafeFragment", "onDestroy called")
+    }
+
     override fun initAfterBinding() {
 
     }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -22,7 +22,9 @@
         tools:layout="@layout/fragment_my_page">
         <action
             android:id="@+id/action_myPageFragment_to_recentlyCafeFragment"
-            app:destination="@id/recentlyCafeFragment" />
+            app:destination="@id/recentlyCafeFragment"
+            app:popUpTo="@id/myPageFragment"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_myPageFragment_to_signInFragment"
             app:destination="@+id/signInFragment" />


### PR DESCRIPTION
- 바텀 네비게이션 마이페이지 탭 들어올때마다 MyPageFragment로 초기화
- onDestroy 로그
- MainActivity에서 최근본매장 들어갈경우 바텀내비게이션 사라지던 코드 삭제