### PR TITLE
[Feat] #140 favorite token

### DIFF
--- a/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoFragment.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoFragment.kt
@@ -1,5 +1,6 @@
 package org.cazait.ui.component.cafeinfo
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -30,6 +31,11 @@ class CafeInfoFragment : Fragment() {
     private val viewModel: CafeInfoViewModel by viewModels()
     private lateinit var viewPagerImageAdapter: CafeImgAdapter
     private lateinit var fragmentList: List<Fragment>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.updateSignInState()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -131,10 +137,20 @@ class CafeInfoFragment : Fragment() {
             bringToFront()
             setOnClickListener {
                 Log.e("ivFavor", "onclick")
-                if (viewModel.isFavoriteCafe.value) {
-                    viewModel.deleteFavoriteCafe()
+                val isLoggedIn = viewModel.signInStateFlow.value
+                if (isLoggedIn) {
+                    if (viewModel.isFavoriteCafe.value) {
+                        viewModel.deleteFavoriteCafeAuth()
+                    } else {
+                        viewModel.postFavoriteCafeAuth()
+                    }
                 } else {
-                    viewModel.saveFavoriteCafe()
+                    AlertDialog.Builder(requireContext())
+                        .setMessage(resources.getString(R.string.need_login))
+                        .setPositiveButton("확인") { dialog, which ->
+                            dialog.dismiss()
+                        }
+                        .show()
                 }
             }
         }

--- a/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafeinfo/CafeInfoViewModel.kt
@@ -62,32 +62,20 @@ class CafeInfoViewModel @Inject constructor(
         }
     }
 
-    fun saveFavoriteCafe() {
+    fun postFavoriteCafeAuth() {
         viewModelScope.launch {
-            val isLoggedIn = userRepository.isLoggedIn().first()
             val currentCafe = cafe ?: return@launch
-
-            if (isLoggedIn) {
-                val userPreference = userRepository.getUserInfo().first()
-                cafeRepository.postFavoriteCafe(userPreference.uuid, currentCafe)
-            } else {
-                cafeRepository.insertFavoriteCafe(currentCafe)
-            }
+            val userPreference = userRepository.getUserInfo().first()
+            cafeRepository.postFavoriteCafeAuth(userPreference.uuid, currentCafe)
             _isFavoriteCafe.value = true
         }
     }
 
-    fun deleteFavoriteCafe() {
+    fun deleteFavoriteCafeAuth() {
         viewModelScope.launch {
-            val isLoggedIn = userRepository.isLoggedIn().first()
             val currentCafe = cafe ?: return@launch
-
-            if (isLoggedIn) {
-                val userPreference = userRepository.getUserInfo().first()
-                cafeRepository.remoteDeleteFavoriteCafe(userPreference.uuid, currentCafe)
-            } else {
-                cafeRepository.localDeleteFavoriteCafe(currentCafe)
-            }
+            val userPreference = userRepository.getUserInfo().first()
+            cafeRepository.deleteFavoriteCafeAuth(userPreference.uuid, currentCafe)
             _isFavoriteCafe.value = false
         }
     }

--- a/app/src/main/java/org/cazait/ui/component/cafelist/CafeListFragment.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafelist/CafeListFragment.kt
@@ -146,7 +146,7 @@ class CafeListFragment : BaseFragment<FragmentCafeListBinding, CafeListViewModel
         findNavController().navigate(CafeListFragmentDirections.actionCafeListFragmentToSearchFragment())
     }
 
-    private fun handleHorizontalCafeList(status: Resource<FavoriteCafes>) {
+    private fun handleHorizontalCafeList(status: Resource<FavoriteCafes>?) {
         when (status) {
             is Resource.Loading -> {}
             is Resource.Error -> handleError(status)
@@ -154,6 +154,8 @@ class CafeListFragment : BaseFragment<FragmentCafeListBinding, CafeListViewModel
                 horizontalAdapter::submitList,
                 status.data?.list ?: emptyList()
             )
+
+            else -> {}
         }
     }
 

--- a/app/src/main/java/org/cazait/ui/component/cafelist/CafeListViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafelist/CafeListViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.location.FusedLocationProviderClient
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.bmsk.data.repository.CafeRepository
@@ -27,8 +29,8 @@ class CafeListViewModel @Inject constructor(
     private val permissionUtil: PermissionUtil,
 ) : BaseViewModel() {
 
-    private val _listFavoritesData = MutableLiveData<Resource<FavoriteCafes>>()
-    val listFavoritesData: LiveData<Resource<FavoriteCafes>>
+    private val _listFavoritesData = MutableLiveData<Resource<FavoriteCafes>?>()
+    val listFavoritesData: LiveData<Resource<FavoriteCafes>?>
         get() = _listFavoritesData
 
     private val _listCafesData = MutableLiveData<Resource<Cafes>>()
@@ -38,6 +40,9 @@ class CafeListViewModel @Inject constructor(
     private val _lastLocationLiveData = MutableLiveData<Location>()
     val lastLocationLiveData: LiveData<Location>
         get() = _lastLocationLiveData
+
+    private val _signInStateFlow = MutableStateFlow(false)
+    val signInStateFlow = _signInStateFlow.asStateFlow()
 
     fun updateCheckCafes() {
         if (_lastLocationLiveData.value != null) {
@@ -63,8 +68,16 @@ class CafeListViewModel @Inject constructor(
     }
 
     private suspend fun fetchUserIdIfLoggedIn(): String? {
-        val isLoggedIn = false /* userRepository.isLoggedIn().first() */
-        return if (isLoggedIn) userRepository.getUserInfo().first().uuid else null
+//        val isLoggedIn = false /* userRepository.isLoggedIn().first() */
+//        return if (isLoggedIn) userRepository.getUserInfo().first().uuid else null
+        updateSignInState()
+        if (_signInStateFlow.value) {
+            val uuid = userRepository.getUserInfo().first().uuid
+            Log.d("유저 uuid", uuid)
+            return uuid
+        } else {
+            return null
+        }
     }
 
     private suspend fun updateCafeListByLocation(userId: String?) {
@@ -78,9 +91,9 @@ class CafeListViewModel @Inject constructor(
 
     private suspend fun updateFavoritesList(userId: String?) {
         if (userId != null) {
-            _listFavoritesData.value = cafeRepository.getListFavorites(userId).first()
+            _listFavoritesData.value = cafeRepository.getListFavoritesAuth(userId).first()
         } else {
-            _listFavoritesData.value = cafeRepository.loadFavoriteCafes().first()
+            _listFavoritesData.value = null
         }
     }
 
@@ -96,6 +109,12 @@ class CafeListViewModel @Inject constructor(
             }
         } else {
             Log.e("Location", "권한이 없습니다.")
+        }
+    }
+
+    fun updateSignInState() {
+        viewModelScope.launch {
+            _signInStateFlow.value = userRepository.isLoggedIn().first()
         }
     }
 }

--- a/app/src/main/java/org/cazait/ui/component/cafelist/CafeListViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/cafelist/CafeListViewModel.kt
@@ -73,7 +73,7 @@ class CafeListViewModel @Inject constructor(
         updateSignInState()
         if (_signInStateFlow.value) {
             val uuid = userRepository.getUserInfo().first().uuid
-            Log.d("유저 uuid", uuid)
+            Log.d("CafeListViewModel 유저 uuid", uuid)
             return uuid
         } else {
             return null

--- a/app/src/main/java/org/cazait/ui/component/map/CafeMapViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/component/map/CafeMapViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.bmsk.data.repository.CafeRepository
 import org.cazait.model.Cafe

--- a/core/data/src/main/java/org/bmsk/data/repository/CafeRepository.kt
+++ b/core/data/src/main/java/org/bmsk/data/repository/CafeRepository.kt
@@ -1,7 +1,6 @@
 package org.bmsk.data.repository
 
 import kotlinx.coroutines.flow.Flow
-import org.cazait.database.dao.RecentlyViewedCafeDAO
 import org.cazait.model.Cafe
 import org.cazait.model.CafeMenus
 import org.cazait.model.CafeReviews
@@ -13,7 +12,7 @@ import org.cazait.model.Resource
 
 interface CafeRepository {
     suspend fun getCafeById(cafeId: Long): Flow<Resource<Cafe>>
-    suspend fun getListFavorites(userId: String): Flow<Resource<FavoriteCafes>>
+    suspend fun getListFavoritesAuth(userId: String): Flow<Resource<FavoriteCafes>>
     suspend fun getListCafes(
         userId: String?,
         latitude: String,
@@ -42,10 +41,10 @@ interface CafeRepository {
 
     suspend fun updateFavoriteCafe(cafe: FavoriteCafe): Boolean
     suspend fun loadFavoriteCafes(): Flow<Resource<FavoriteCafes>>
-    suspend fun postFavoriteCafe(userId: String, cafe: FavoriteCafe): Boolean
-    suspend fun postFavoriteCafe(userId: String, cafe: Cafe): Boolean
-    suspend fun remoteDeleteFavoriteCafe(userId: String, cafe: Cafe): Boolean
-    suspend fun remoteDeleteFavoriteCafe(userId: String, cafe: FavoriteCafe): Boolean
+    suspend fun postFavoriteCafeAuth(userId: String, cafe: FavoriteCafe): Boolean
+    suspend fun postFavoriteCafeAuth(userId: String, cafe: Cafe): Boolean
+    suspend fun deleteFavoriteCafeAuth(userId: String, cafe: Cafe): Boolean
+    suspend fun deleteFavoriteCafeAuth(userId: String, cafe: FavoriteCafe): Boolean
     suspend fun localDeleteFavoriteCafe(cafe: Cafe): Boolean
     suspend fun localDeleteFavoriteCafe(cafe: FavoriteCafe): Boolean
     suspend fun insertRecentlyViewedCafe(cafe: Cafe): Boolean

--- a/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
+++ b/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
@@ -87,9 +87,9 @@ class CafeRepositoryImpl @Inject constructor(
         }.flowOn(ioDispatcher)
     }
 
-    override suspend fun getListFavorites(userId: String): Flow<Resource<FavoriteCafes>> {
+    override suspend fun getListFavoritesAuth(userId: String): Flow<Resource<FavoriteCafes>> {
         return flow {
-            when (val response = cafeListRemoteData.getListFavorites(userId)) {
+            when (val response = cafeListRemoteData.getListFavoritesAuth(userId)) {
                 is DataResponse.Success -> {
                     val fc = FavoriteCafes(
                         response.data?.favorites?.map {
@@ -153,7 +153,8 @@ class CafeRepositoryImpl @Inject constructor(
         content: String
     ): Flow<Resource<String>> {
         return flow {
-            when (val response = cafeInfoRemoteData.postReviewAuth(userId, cafeId, score, content)) {
+            when (val response =
+                cafeInfoRemoteData.postReviewAuth(userId, cafeId, score, content)) {
                 is DataResponse.Success -> {
                     val message: String =
                         response.data?.message ?: ""
@@ -200,26 +201,46 @@ class CafeRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun postFavoriteCafe(
+    override suspend fun postFavoriteCafeAuth(
         userId: String,
         cafe: FavoriteCafe
     ): Boolean {
-        return cafeInfoRemoteData.postFavoriteCafe(userId, cafe.cafeId) is DataResponse.Success
+        return try {
+            cafeInfoRemoteData.postFavoriteCafeAuth(userId, cafe.cafeId) is DataResponse.Success
+            true
+        } catch (e: IOException) {
+            false
+        }
     }
 
-    override suspend fun postFavoriteCafe(
+    override suspend fun postFavoriteCafeAuth(
         userId: String,
         cafe: Cafe
     ): Boolean {
-        return cafeInfoRemoteData.postFavoriteCafe(userId, cafe.cafeId) is DataResponse.Success
+        return try {
+            cafeInfoRemoteData.postFavoriteCafeAuth(userId, cafe.cafeId) is DataResponse.Success
+            true
+        } catch (e: IOException) {
+            false
+        }
     }
 
-    override suspend fun remoteDeleteFavoriteCafe(userId: String, cafe: Cafe): Boolean {
-        return cafeInfoRemoteData.deleteFavoriteCafe(userId, cafe.cafeId) is DataResponse.Success
+    override suspend fun deleteFavoriteCafeAuth(userId: String, cafe: Cafe): Boolean {
+        return try {
+            cafeInfoRemoteData.deleteFavoriteCafeAuth(userId, cafe.cafeId) is DataResponse.Success
+            true
+        } catch (e: IOException) {
+            false
+        }
     }
 
-    override suspend fun remoteDeleteFavoriteCafe(userId: String, cafe: FavoriteCafe): Boolean {
-        return cafeInfoRemoteData.deleteFavoriteCafe(userId, cafe.cafeId) is DataResponse.Success
+    override suspend fun deleteFavoriteCafeAuth(userId: String, cafe: FavoriteCafe): Boolean {
+        return try {
+            cafeInfoRemoteData.deleteFavoriteCafeAuth(userId, cafe.cafeId) is DataResponse.Success
+            true
+        } catch (e: IOException) {
+            false
+        }
     }
 
     override suspend fun localDeleteFavoriteCafe(cafe: Cafe): Boolean {

--- a/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
+++ b/core/data/src/main/java/org/bmsk/data/repository/CafeRepositoryImpl.kt
@@ -65,6 +65,7 @@ class CafeRepositoryImpl @Inject constructor(
     ): Flow<Resource<Cafes>> {
         val query =
             ListCafesReq(latitude = latitude, longitude = longitude, sort = sort, limit = limit)
+        Log.d("CafeRepository 유저 ID", userId.toString())
 
         return flow {
             val response = if (userId == null) {

--- a/core/model/src/main/java/org/cazait/model/CafeMenu.kt
+++ b/core/model/src/main/java/org/cazait/model/CafeMenu.kt
@@ -7,7 +7,7 @@ data class CafeMenus(
 data class CafeMenu(
     val menuId: Long,
     val menuName: String,
-    val menuDesc: String,
+    val menuDesc: String?,
     val menuPrice: Int,
     val image: String
 ) {

--- a/core/network/src/main/java/org/cazait/network/api/auth/CafeAuthService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/auth/CafeAuthService.kt
@@ -1,0 +1,18 @@
+package org.cazait.network.api.auth
+
+import org.cazait.network.model.dto.response.ListCafesRes
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface CafeAuthService {
+    @GET("/api/cafes/all/user/{userId}")
+    suspend fun getListCafes(
+        @Path("userId") userId: String,
+        @Query("longitude") longitude: String,
+        @Query("latitude") latitude: String,
+        @Query("sort") sort: String,
+        @Query("limit") limit: String,
+    ): Response<ListCafesRes>
+}

--- a/core/network/src/main/java/org/cazait/network/api/auth/FavoriteService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/auth/FavoriteService.kt
@@ -1,0 +1,29 @@
+package org.cazait.network.api.auth
+
+import org.cazait.network.model.dto.response.DeleteFavoriteCafeRes
+import org.cazait.network.model.dto.response.ListFavoritesRes
+import org.cazait.network.model.dto.response.PostFavoriteCafeRes
+import retrofit2.Response
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface FavoriteService {
+    @POST("/api/favorites/user/{userId}/cafe/{cafeId}")
+    suspend fun postFavoriteCafeAuth(
+        @Path("userId") userId: String,
+        @Path("cafeId") cafeId: Long,
+    ): Response<PostFavoriteCafeRes>
+
+    @DELETE("/api/favorites/delete/{userId}/{cafeId}")
+    suspend fun deleteFavoriteCafeAuth(
+        @Path("userId") userId: String,
+        @Path("cafeId") cafeId: Long,
+    ): Response<DeleteFavoriteCafeRes>
+
+    @GET("/api/favorites/user/{userId}")
+    suspend fun getListFavoritesAuth(
+        @Path("userId") userId: String
+    ): Response<ListFavoritesRes>
+}

--- a/core/network/src/main/java/org/cazait/network/api/auth/ReviewService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/auth/ReviewService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.http.Path
 
-interface AuthedService {
+interface ReviewService {
     @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
     suspend fun postReviewAuth(
         @Path("userId") userId: String,

--- a/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
@@ -3,14 +3,9 @@ package org.cazait.network.api.unauth
 import org.cazait.network.model.dto.response.CafeMenuRes
 import org.cazait.network.model.dto.response.CafeResTemp
 import org.cazait.network.model.dto.response.CafeReviewRes
-import org.cazait.network.model.dto.response.DeleteFavoriteCafeRes
 import org.cazait.network.model.dto.response.ListCafesRes
-import org.cazait.network.model.dto.response.ListFavoritesRes
-import org.cazait.network.model.dto.response.PostFavoriteCafeRes
 import retrofit2.Response
-import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -28,11 +23,6 @@ interface CafeService {
         @Query("sort") sort: String,
         @Query("limit") limit: String,
     ): Response<ListCafesRes>
-
-    @GET("/api/favorites/user/{userId}")
-    suspend fun getListFavorites(
-        @Path("userId") userId: String
-    ): Response<ListFavoritesRes>
 
     @GET("api/cafes/all")
     suspend fun getListCafesWithGuest(
@@ -62,25 +52,6 @@ interface CafeService {
         @Query("score") score: Int?,
         @Query("lastId") lastId: Long?
     ): Response<CafeReviewRes>
-
-    @POST("/api/favorites/user/{userId}/cafe/{cafeId}")
-    suspend fun postFavoriteCafe(
-        @Path("userId") userId: String,
-        @Path("cafeId") cafeId: Long,
-    ): Response<PostFavoriteCafeRes>
-
-    @DELETE("/api/favorites/delete/{userId}/{cafeId}")
-    suspend fun deleteFavoriteCafe(
-        @Path("userId") userId: String,
-        @Path("cafeId") cafeId: Long,
-    ): Response<DeleteFavoriteCafeRes>
-
-//    @POST("/api/reviews/user/{userId}/cafe/{cafeId}")
-//    suspend fun postReviewAuth(
-//        @Path("userId") userId: Long,
-//        @Path("cafeId") cafeId: Long,
-//        @Body reviewPostReq: CafeReviewPostReq,
-//    ): Response<CafeReviewPostRes>
 
     @GET("/api/cafes/name/{cafeName}")
     suspend fun getCafeSearch(

--- a/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
+++ b/core/network/src/main/java/org/cazait/network/api/unauth/CafeService.kt
@@ -15,15 +15,6 @@ interface CafeService {
         @Path("cafeId") cafeId: Long,
     ): Response<CafeResTemp>
 
-    @GET("/api/cafes/all/user/{userId}")
-    suspend fun getListCafes(
-        @Path("userId") userId: String,
-        @Query("longitude") longitude: String,
-        @Query("latitude") latitude: String,
-        @Query("sort") sort: String,
-        @Query("limit") limit: String,
-    ): Response<ListCafesRes>
-
     @GET("api/cafes/all")
     suspend fun getListCafesWithGuest(
         @Query("longitude") longitude: String,

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
@@ -2,7 +2,7 @@ package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
 import org.cazait.network.api.unauth.CafeService
-import org.cazait.network.api.auth.AuthedService
+import org.cazait.network.api.auth.ReviewService
 import org.cazait.network.di.Authenticated
 import org.cazait.network.error.NETWORK_ERROR
 import org.cazait.network.model.dto.DataResponse
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 class CafeInfoRemoteData @Inject constructor(
     private val cafeService: CafeService,
-    @Authenticated private val cafeServiceAuth: AuthedService,
+    @Authenticated private val cafeServiceAuth: ReviewService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeInfoRemoteDataSource {
     override suspend fun getCafe(cafeId: Long): DataResponse<CafeResTemp> {

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteData.kt
@@ -1,6 +1,7 @@
 package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
+import org.cazait.network.api.auth.FavoriteService
 import org.cazait.network.api.unauth.CafeService
 import org.cazait.network.api.auth.ReviewService
 import org.cazait.network.di.Authenticated
@@ -20,6 +21,7 @@ import javax.inject.Inject
 class CafeInfoRemoteData @Inject constructor(
     private val cafeService: CafeService,
     @Authenticated private val cafeServiceAuth: ReviewService,
+    @Authenticated private val favoriteServiceAuth: FavoriteService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeInfoRemoteDataSource {
     override suspend fun getCafe(cafeId: Long): DataResponse<CafeResTemp> {
@@ -93,12 +95,12 @@ class CafeInfoRemoteData @Inject constructor(
         }
     }
 
-    override suspend fun postFavoriteCafe(
+    override suspend fun postFavoriteCafeAuth(
         userId: String,
         cafeId: Long
     ): DataResponse<PostFavoriteCafeRes> {
         return when (val response = processCall {
-            cafeService.postFavoriteCafe(
+            favoriteServiceAuth.postFavoriteCafeAuth(
                 userId,
                 cafeId,
             )
@@ -113,12 +115,12 @@ class CafeInfoRemoteData @Inject constructor(
         }
     }
 
-    override suspend fun deleteFavoriteCafe(
+    override suspend fun deleteFavoriteCafeAuth(
         userId: String,
         cafeId: Long,
     ): DataResponse<DeleteFavoriteCafeRes> {
         return when (val response = processCall {
-            cafeService.deleteFavoriteCafe(
+            favoriteServiceAuth.deleteFavoriteCafeAuth(
                 userId,
                 cafeId,
             )

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteDataSource.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeInfoRemoteDataSource.kt
@@ -25,7 +25,6 @@ interface CafeInfoRemoteDataSource {
         score: Int,
         content: String,
     ): DataResponse<CafeReviewPostRes>
-
-    suspend fun postFavoriteCafe(userId: String, cafeId: Long): DataResponse<PostFavoriteCafeRes>
-    suspend fun deleteFavoriteCafe(userId: String, cafeId: Long): DataResponse<DeleteFavoriteCafeRes>
+    suspend fun postFavoriteCafeAuth(userId: String, cafeId: Long): DataResponse<PostFavoriteCafeRes>
+    suspend fun deleteFavoriteCafeAuth(userId: String, cafeId: Long): DataResponse<DeleteFavoriteCafeRes>
 }

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
@@ -1,7 +1,9 @@
 package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
+import org.cazait.network.api.auth.FavoriteService
 import org.cazait.network.api.unauth.CafeService
+import org.cazait.network.di.Authenticated
 import org.cazait.network.error.NETWORK_ERROR
 import org.cazait.network.model.dto.DataResponse
 import org.cazait.network.model.dto.request.ListCafesReq
@@ -14,6 +16,7 @@ import javax.inject.Inject
 
 class CafeListRemoteData @Inject constructor(
     private val cafeService: CafeService,
+    @Authenticated private val favoriteCafeService: FavoriteService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeListRemoteDataSource {
     override suspend fun getListCafes(
@@ -65,9 +68,9 @@ class CafeListRemoteData @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override suspend fun getListFavorites(userId: String): DataResponse<ListFavoritesRes> {
+    override suspend fun getListFavoritesAuth(userId: String): DataResponse<ListFavoritesRes> {
         return when (val response = processCall {
-            cafeService.getListFavorites(userId)
+            favoriteCafeService.getListFavoritesAuth(userId)
         }) {
             is ListFavoritesRes -> {
                 DataResponse.Success(response)

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteData.kt
@@ -1,6 +1,7 @@
 package org.cazait.network.datasource
 
 import org.cazait.network.NetworkConnectivity
+import org.cazait.network.api.auth.CafeAuthService
 import org.cazait.network.api.auth.FavoriteService
 import org.cazait.network.api.unauth.CafeService
 import org.cazait.network.di.Authenticated
@@ -16,6 +17,7 @@ import javax.inject.Inject
 
 class CafeListRemoteData @Inject constructor(
     private val cafeService: CafeService,
+    @Authenticated private val cafeAuthService: CafeAuthService,
     @Authenticated private val favoriteCafeService: FavoriteService,
     private val networkConnectivity: NetworkConnectivity,
 ) : CafeListRemoteDataSource {
@@ -24,10 +26,10 @@ class CafeListRemoteData @Inject constructor(
         query: ListCafesReq
     ): DataResponse<ListCafesRes> {
         return when (val response = processCall {
-            cafeService.getListCafes(
+            cafeAuthService.getListCafes(
                 userId = userId,
-                latitude = query.latitude,
-                longitude = query.longitude,
+                query.longitude,
+                query.latitude,
                 sort = query.sort,
                 limit = query.limit
             )

--- a/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteDataSource.kt
+++ b/core/network/src/main/java/org/cazait/network/datasource/CafeListRemoteDataSource.kt
@@ -7,7 +7,7 @@ import org.cazait.network.model.dto.response.ListFavoritesRes
 import org.cazait.network.model.dto.response.PostFavoriteCafeRes
 
 interface CafeListRemoteDataSource {
-    suspend fun getListFavorites(userId: String): DataResponse<ListFavoritesRes>
+    suspend fun getListFavoritesAuth(userId: String): DataResponse<ListFavoritesRes>
     suspend fun getListCafes(userId: String, query: ListCafesReq): DataResponse<ListCafesRes>
     suspend fun getListCafesWithGuest(query: ListCafesReq): DataResponse<ListCafesRes>
     suspend fun postFavoriteCafe(userId: String, cafeId: Long): DataResponse<PostFavoriteCafeRes>

--- a/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
@@ -1,7 +1,6 @@
 package org.cazait.network.di
 
 import android.content.Context
-import android.util.Log
 import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.cazait.network.api.auth.CafeAuthService
 import org.cazait.network.api.auth.FavoriteService
 import org.cazait.network.api.unauth.AuthService
 import org.cazait.network.api.auth.ReviewService
@@ -57,13 +58,13 @@ object ServiceModule {
     ): FavoriteService {
         return retrofit.create(FavoriteService::class.java)
     }
-//
-//    @Provides
-//    @Singleton
-//    @Authenticated
-//    fun providesAuthServiceAuth(
-//        @Authenticated retrofit: Retrofit
-//    ): AuthService {
-//        return retrofit.create(AuthService::class.java)
-//    }
+
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesCafeAuthServiceAuth(
+        @Authenticated retrofit: Retrofit
+    ): CafeAuthService {
+        return retrofit.create(CafeAuthService::class.java)
+    }
 }

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -5,7 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.cazait.network.api.unauth.AuthService
-import org.cazait.network.api.auth.AuthedService
+import org.cazait.network.api.auth.ReviewService
 import org.cazait.network.api.unauth.CafeService
 import org.cazait.network.api.unauth.UserService
 import retrofit2.Retrofit
@@ -44,8 +44,8 @@ object ServiceModule {
     @Authenticated
     fun providesCafeServiceAuth(
         @Authenticated retrofit: Retrofit
-    ): AuthedService {
-        return retrofit.create(AuthedService::class.java)
+    ): ReviewService {
+        return retrofit.create(ReviewService::class.java)
     }
 
 //    @Provides

--- a/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/ServiceModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.cazait.network.api.auth.FavoriteService
 import org.cazait.network.api.unauth.AuthService
 import org.cazait.network.api.auth.ReviewService
 import org.cazait.network.api.unauth.CafeService
@@ -42,20 +43,20 @@ object ServiceModule {
     @Provides
     @Singleton
     @Authenticated
-    fun providesCafeServiceAuth(
+    fun providesReviewServiceAuth(
         @Authenticated retrofit: Retrofit
     ): ReviewService {
         return retrofit.create(ReviewService::class.java)
     }
 
-//    @Provides
-//    @Singleton
-//    @Authenticated
-//    fun providesUserServiceAuth(
-//        @Authenticated retrofit: Retrofit
-//    ): UserService {
-//        return retrofit.create(UserService::class.java)
-//    }
+    @Provides
+    @Singleton
+    @Authenticated
+    fun providesFavoriteServiceAuth(
+        @Authenticated retrofit: Retrofit
+    ): FavoriteService {
+        return retrofit.create(FavoriteService::class.java)
+    }
 //
 //    @Provides
 //    @Singleton


### PR DESCRIPTION
## 주의! 현재 추가적으로 해결해야하는 부분
1. CafeListFragment가 아닌, CafeInfoFragment에서 다른 BNV(마이페이지, 지도, 더보기)로 갔다가 다시 메인 BNV를 누르면 앱이 튕김. --> 홈화면을 누르면 CafeInfoFrag가 아닌 CafeListFrag로 가도록 수정해야할듯.
2. CafeInfoFrag에서 찜하기 누르면 하트가 바로 검은색으로 바뀌지 않는 문제. --> CafeListFrag갔다가 다시 InfoFrag로 돌아오면 바뀌어져 있음.
3. 일정 시간이 지나면 찜하기 등록 및 토큰이 필요한 서비스에서 에러가 남. --> refreshToken 구현해야할듯. UserPreference 관련 논의 필요할듯
4. 로그아웃을 하면 찜한 매장 리스트도 사라져야 하는데 남아있음..
5. 원인은 모르겠지만 CafeListFrag에서 에러메시지가 계속 발생함. 근데 실행 자체는 됨.

## 작업한 내용
- package org.cazait.model -> CafeMenu -> menuDesc를 임시로 nullable하게 변경.
- 현재 서버에서 메뉴에 대한 설명 없음.
- FavoriteService api에 작성
- remoteData와 repository 기존에 작성해 놓았던 코드 수정
- 로컬 저장 기능은 사용 X
- 찜한 매장 GET은 CafeListFrag,RemoteData에 있음
- 찜한 매장 POST, DELETE는 CafeInfoFrag, CafeInfoRemoteData에 있음
- CafeRepository는 공통으로 사용
- 서비스 모듈에 CafeAuthService 추가
- CafeMapViewModel에서 안쓰이는 주석 삭제