### PR TITLE
[Feat] #152 리뷰 수정 및 삭제, 신고

### DIFF
--- a/app/src/main/java/org/cazait/ui/adapter/CafeInfoReviewAdapter.kt
+++ b/app/src/main/java/org/cazait/ui/adapter/CafeInfoReviewAdapter.kt
@@ -8,16 +8,16 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.cazait.model.CafeReview
 import org.cazait.databinding.ItemCafeInfoReviewBinding
+import org.cazait.ui.cafeinfo.detail.clicklistener.ReviewItemClick
 import org.cazait.utils.toGone
 import org.cazait.utils.toVisible
 
-class CafeInfoReviewAdapter(private val uuid: String?) :
+class CafeInfoReviewAdapter(private val uuid: String?, private val listener: ReviewItemClick) :
     ListAdapter<CafeReview, CafeInfoReviewAdapter.CafeInfoReviewViewHolder>(diffUtil) {
 
     inner class CafeInfoReviewViewHolder(
         private val binding: ItemCafeInfoReviewBinding
     ) : RecyclerView.ViewHolder(binding.root) {
-
         fun bind(item: CafeReview) {
             Log.d("Review Adapter 사용자 uuid", uuid.toString())
             if (item.userId == uuid) {
@@ -30,6 +30,15 @@ class CafeInfoReviewAdapter(private val uuid: String?) :
             binding.rating.progress = item.score
             binding.tvUser.text = item.userId
             binding.tvContent.text = item.content
+            binding.tvReviewEdit.setOnClickListener {
+                listener.onEditClick(item)
+            }
+            binding.tvReviewDelete.setOnClickListener {
+                listener.onDeleteClick(item)
+            }
+            binding.tvReviewReport.setOnClickListener {
+                listener.onReportClick(item)
+            }
         }
     }
 

--- a/app/src/main/java/org/cazait/ui/adapter/CafeInfoReviewAdapter.kt
+++ b/app/src/main/java/org/cazait/ui/adapter/CafeInfoReviewAdapter.kt
@@ -1,5 +1,6 @@
 package org.cazait.ui.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -7,8 +8,10 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.cazait.model.CafeReview
 import org.cazait.databinding.ItemCafeInfoReviewBinding
+import org.cazait.utils.toGone
+import org.cazait.utils.toVisible
 
-class CafeInfoReviewAdapter :
+class CafeInfoReviewAdapter(private val uuid: String?) :
     ListAdapter<CafeReview, CafeInfoReviewAdapter.CafeInfoReviewViewHolder>(diffUtil) {
 
     inner class CafeInfoReviewViewHolder(
@@ -16,8 +19,16 @@ class CafeInfoReviewAdapter :
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: CafeReview) {
+            Log.d("Review Adapter 사용자 uuid", uuid.toString())
+            if (item.userId == uuid) {
+                binding.layoutNotLogin.toGone()
+                binding.layoutLogin.toVisible()
+            } else {
+                binding.layoutLogin.toGone()
+                binding.layoutNotLogin.toVisible()
+            }
             binding.rating.progress = item.score
-            binding.tvUser.text = item.userId.toString()
+            binding.tvUser.text = item.userId
             binding.tvContent.text = item.content
         }
     }

--- a/app/src/main/java/org/cazait/ui/cafeinfo/CafeInfoViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/CafeInfoViewModel.kt
@@ -15,6 +15,7 @@ import org.cazait.model.Cafe
 import org.cazait.model.CafeMenus
 import org.cazait.model.CafeReviews
 import org.cazait.model.Resource
+import org.cazait.model.local.UserPreference
 import org.cazait.ui.base.BaseViewModel
 import javax.inject.Inject
 
@@ -38,6 +39,9 @@ class CafeInfoViewModel @Inject constructor(
 
     private val _signInStateFlow = MutableStateFlow(false)
     val signInStateFlow = _signInStateFlow.asStateFlow()
+
+    private var _uuid = MutableStateFlow<String?>(null)
+    val uuid = _uuid.asStateFlow()
 
     fun initViewModel(cafe: Cafe, isFavorite: Boolean) {
         this.cafe = cafe
@@ -88,6 +92,7 @@ class CafeInfoViewModel @Inject constructor(
     fun updateSignInState() {
         viewModelScope.launch {
             _signInStateFlow.value = userRepository.isLoggedIn().first()
+            _uuid.value = userRepository.getUserInfo().first().uuid
         }
     }
 

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -130,6 +130,7 @@ class CafeInfoReviewFragment(
                 ""
             )
         )
+    }
 
     override fun onEditClick(item: CafeReview) {
         val content = item.content

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -55,7 +55,7 @@ class CafeInfoReviewFragment(
         binding.fabEditReview.setOnClickListener {
             val isLoggedIn = viewModel.signInStateFlow.value
             if (isLoggedIn) {
-                navigateToReviewWriteFragment(cafe)
+                navigateToReviewWriteFragment(cafe, 1f, "")
             } else {
                 AlertDialog.Builder(requireContext())
                     .setMessage(resources.getString(R.string.need_login))
@@ -120,14 +120,14 @@ class CafeInfoReviewFragment(
         }
     }
 
-    private fun navigateToReviewWriteFragment(cafe: Cafe) {
+    private fun navigateToReviewWriteFragment(cafe: Cafe, score: Float, content: String) {
         val parentFragment = parentFragment
         Log.d("CafeInfoReviewFragment의 부모 Fragment는 누구?", parentFragment.toString())
         parentFragment?.findNavController()?.navigate(
             CafeInfoFragmentDirections.actionCafeInfoFragmentToReviewWriteFragment(
                 cafe,
-                1f,
-                ""
+                score,
+                content
             )
         )
     }
@@ -135,6 +135,7 @@ class CafeInfoReviewFragment(
     override fun onEditClick(item: CafeReview) {
         val content = item.content
         val rating = item.score
+        navigateToReviewWriteFragment(cafe, rating.toFloat(), content)
     }
 
     override fun onDeleteClick(item: CafeReview) {

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -11,11 +11,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.cazait.R
 import org.cazait.databinding.FragmentCafeInfoReviewBinding
 import org.cazait.model.Cafe
+import org.cazait.model.CafeReview
 import org.cazait.model.CafeReviews
 import org.cazait.model.Resource
 import org.cazait.ui.adapter.CafeInfoReviewAdapter
 import org.cazait.ui.adapter.ItemDecoration
 import org.cazait.ui.cafeinfo.CafeInfoViewModel
+import org.cazait.ui.cafeinfo.detail.clicklistener.ReviewItemClick
 import org.cazait.ui.review.ReviewEditActivity
 import org.cazait.utils.observe
 import org.cazait.utils.toGone
@@ -26,7 +28,7 @@ import kotlin.math.roundToInt
 class CafeInfoReviewFragment(
     private val cafe: Cafe,
     private val viewModel: CafeInfoViewModel
-) : Fragment() {
+) : Fragment(), ReviewItemClick {
     private lateinit var binding: FragmentCafeInfoReviewBinding
     private lateinit var reviewAdapter: CafeInfoReviewAdapter
 
@@ -74,7 +76,7 @@ class CafeInfoReviewFragment(
     private fun initAdapter() {
         val userUuid = viewModel.uuid.value
         Log.d("ReviewFrag 유저 uuid", userUuid.toString())
-        reviewAdapter = CafeInfoReviewAdapter(userUuid)
+        reviewAdapter = CafeInfoReviewAdapter(userUuid, this)
         binding.rvCafeInfoReviews.adapter = this.reviewAdapter
         binding.rvCafeInfoReviews.addItemDecoration(
             ItemDecoration(
@@ -116,5 +118,18 @@ class CafeInfoReviewFragment(
                 binding.lottieReview.toGone()
             }
         }
+    }
+
+    override fun onEditClick(item: CafeReview) {
+        val content = item.content
+        val rating = item.score
+    }
+
+    override fun onDeleteClick(item: CafeReview) {
+
+    }
+
+    override fun onReportClick(item: CafeReview) {
+
     }
 }

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -72,7 +72,9 @@ class CafeInfoReviewFragment(
     }
 
     private fun initAdapter() {
-        reviewAdapter = CafeInfoReviewAdapter()
+        val userUuid = viewModel.uuid.value
+        Log.d("ReviewFrag 유저 uuid", userUuid.toString())
+        reviewAdapter = CafeInfoReviewAdapter(userUuid)
         binding.rvCafeInfoReviews.adapter = this.reviewAdapter
         binding.rvCafeInfoReviews.addItemDecoration(
             ItemDecoration(

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -12,12 +12,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.cazait.R
 import org.cazait.databinding.FragmentCafeInfoReviewBinding
 import org.cazait.model.Cafe
+import org.cazait.model.CafeReview
 import org.cazait.model.CafeReviews
 import org.cazait.model.Resource
 import org.cazait.ui.adapter.CafeInfoReviewAdapter
 import org.cazait.ui.adapter.ItemDecoration
 import org.cazait.ui.cafeinfo.CafeInfoFragmentDirections
 import org.cazait.ui.cafeinfo.CafeInfoViewModel
+import org.cazait.ui.cafeinfo.detail.clicklistener.ReviewItemClick
 import org.cazait.utils.observe
 import org.cazait.utils.toGone
 import org.cazait.utils.toVisible
@@ -27,7 +29,7 @@ import kotlin.math.roundToInt
 class CafeInfoReviewFragment(
     private val cafe: Cafe,
     private val viewModel: CafeInfoViewModel
-) : Fragment() {
+) : Fragment(), ReviewItemClick {
     private lateinit var binding: FragmentCafeInfoReviewBinding
     private lateinit var reviewAdapter: CafeInfoReviewAdapter
 
@@ -74,7 +76,7 @@ class CafeInfoReviewFragment(
     private fun initAdapter() {
         val userUuid = viewModel.uuid.value
         Log.d("ReviewFrag 유저 uuid", userUuid.toString())
-        reviewAdapter = CafeInfoReviewAdapter(userUuid)
+        reviewAdapter = CafeInfoReviewAdapter(userUuid, this)
         binding.rvCafeInfoReviews.adapter = this.reviewAdapter
         binding.rvCafeInfoReviews.addItemDecoration(
             ItemDecoration(
@@ -128,5 +130,17 @@ class CafeInfoReviewFragment(
                 ""
             )
         )
+
+    override fun onEditClick(item: CafeReview) {
+        val content = item.content
+        val rating = item.score
+    }
+
+    override fun onDeleteClick(item: CafeReview) {
+
+    }
+
+    override fun onReportClick(item: CafeReview) {
+
     }
 }

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/CafeInfoReviewFragment.kt
@@ -2,6 +2,7 @@ package org.cazait.ui.cafeinfo.detail
 
 import android.app.AlertDialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -71,7 +72,9 @@ class CafeInfoReviewFragment(
     }
 
     private fun initAdapter() {
-        reviewAdapter = CafeInfoReviewAdapter()
+        val userUuid = viewModel.uuid.value
+        Log.d("ReviewFrag 유저 uuid", userUuid.toString())
+        reviewAdapter = CafeInfoReviewAdapter(userUuid)
         binding.rvCafeInfoReviews.adapter = this.reviewAdapter
         binding.rvCafeInfoReviews.addItemDecoration(
             ItemDecoration(

--- a/app/src/main/java/org/cazait/ui/cafeinfo/detail/clicklistener/ReviewItemClick.kt
+++ b/app/src/main/java/org/cazait/ui/cafeinfo/detail/clicklistener/ReviewItemClick.kt
@@ -1,0 +1,9 @@
+package org.cazait.ui.cafeinfo.detail.clicklistener
+
+import org.cazait.model.CafeReview
+
+interface ReviewItemClick {
+    fun onEditClick(item: CafeReview)
+    fun onDeleteClick(item: CafeReview)
+    fun onReportClick(item: CafeReview)
+}

--- a/app/src/main/res/layout/item_cafe_info_review.xml
+++ b/app/src/main/res/layout/item_cafe_info_review.xml
@@ -26,6 +26,87 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <FrameLayout
+            android:id="@+id/layout_login"
+            android:layout_width="82dp"
+            android:layout_height="30dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="17.55dp"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/tv_review_edit"
+                    style="@style/TextValue_B"
+                    android:layout_width="40dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:text="@string/review_edit"
+                    android:textSize="13sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:id="@+id/view_divide"
+                    android:layout_width="2dp"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:background="@color/cafe_list_orange"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/tv_review_delete"
+                    app:layout_constraintStart_toEndOf="@+id/tv_review_edit"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_review_delete"
+                    style="@style/TextValue_B"
+                    android:layout_width="40dp"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:text="@string/review_delete"
+                    android:textSize="13sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/layout_not_login"
+            android:layout_width="82dp"
+            android:layout_height="30dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="17.55dp"
+            android:visibility="visible"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/tv_review_report"
+                    style="@style/TextValue_B"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:text="@string/review_report"
+                    android:textSize="13sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </FrameLayout>
+
         <TextView
             android:id="@+id/tv_user"
             style="@style/TextValue_B"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,9 @@
     <string name="no_menu">아직 준비된 메뉴가 없어요..😢</string>
     <string name="no_review">아직 등록된 리뷰가 없어요..ㅠ\n❤️리뷰 등록해줘잉❤️</string>
     <string name="need_login">로그인이 필요한 서비스입니다.</string>
+    <string name="review_edit">수정</string>
+    <string name="review_delete">삭제</string>
+    <string name="review_report">신고</string>
 
     <!-- Item Cafe Menu -->
     <string name="menu_name">아메리카노</string>

--- a/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
+++ b/core/network/src/main/java/org/cazait/network/di/RetrofitModule.kt
@@ -103,14 +103,14 @@ object RetrofitModule {
     @Singleton
     @Authenticated
     fun providesHeaderInterceptorAuth(userPreferenceRepository: UserPreferenceRepository): Interceptor {
-        val user = runBlocking(Dispatchers.IO) {
-            kotlin.runCatching {
-                userPreferenceRepository.getUserPreference().first()
-            }.getOrDefault(UserPreference.getDefaultInstance())
-        }
-
         return Interceptor { chain ->
-            var accessToken = user.accessToken
+            val user = runBlocking(Dispatchers.IO) {
+                kotlin.runCatching {
+                    userPreferenceRepository.getUserPreference().first()
+                }.getOrDefault(UserPreference.getDefaultInstance())
+            }
+
+            val accessToken = user.accessToken
 
             val original = chain.request()
             val request = original.newBuilder()


### PR DESCRIPTION
## 현재는 수정/삭제/신고 레이아웃 추가만 구현.
- 수정 버튼 누르면 ReviewWriteFragment로 넘어가기는 하지만 '작성하기'버튼 클릭시 서버에 보내는 요청은 일반 리뷰 작성과 동일
(reviewId가 없기에..)

## 작업 내용
- Click 인터페이스 작성
- Adpater와 Fragment에 등록
- 각각의 Textview를 클릭했을 때의 이벤트를 CafeInfoReviewFragment에서 작성해주면 됨
- navigateToReviewWriteFrag 함수에 score와 content 인자 추가.
- onEditClick을 했을 때 해당 리뷰의 내용과 점수를 ReviewFragment에 전달 가능
-처음 작성할 때에는 score는 1.0, content는 ""를 전달

### 나머지는 [Discussion 참고](https://github.com/CaZaIt/CaZaIt-Android-Private/discussions/153) 