### PR TITLE
[Fix] 아이디 찾기에서 비밀번호 찾기로 넘어갈 때의 UserUUID

### DIFF
--- a/app/src/main/java/org/cazait/ui/findaccount/findid/FindUserIdViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/findaccount/findid/FindUserIdViewModel.kt
@@ -1,9 +1,43 @@
 package org.cazait.ui.findaccount.findid
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import org.bmsk.data.repository.UserRepository
+import org.cazait.model.Check
+import org.cazait.model.Resource
 import org.cazait.ui.base.BaseViewModel
+import org.cazait.utils.SingleEvent
 import javax.inject.Inject
 
 @HiltViewModel
-class FindUserIdViewModel @Inject constructor() : BaseViewModel() {
+class FindUserIdViewModel @Inject constructor(private val userRepository: UserRepository) :
+    BaseViewModel() {
+    private val _checkIdProcess = MutableLiveData<Resource<Check>?>()
+    val checkIdProcess: LiveData<Resource<Check>?>
+        get() = _checkIdProcess
+
+    private val _showToast = MutableLiveData<SingleEvent<Any>>()
+    val showToast: LiveData<SingleEvent<Any>>
+        get() = _showToast
+
+    fun checkId(id: String) {
+        viewModelScope.launch {
+            _checkIdProcess.value = Resource.Loading()
+            userRepository.checkUserIdDB(id, "true").collect {
+                _checkIdProcess.value = it
+            }
+        }
+    }
+
+    fun showToastMessage(errorMessage: String?) {
+        if (errorMessage == null) return
+        _showToast.value = SingleEvent(errorMessage)
+    }
+
+    fun initViewModel() {
+        _checkIdProcess.value = null
+    }
 }

--- a/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordFragment.kt
+++ b/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordFragment.kt
@@ -27,6 +27,7 @@ class FindUserPasswordFragment :
     private var passwordFlag = false
     private var passwordCheckFlag = false
     override fun initView() {
+        viewModel.initViewModel()
         binding.apply {
             clTop.includedTvTitle.text = resources.getString(R.string.btn_find_password)
             clTop.btnBack.setOnClickListener {

--- a/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordFragment.kt
+++ b/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordFragment.kt
@@ -50,16 +50,17 @@ class FindUserPasswordFragment :
 
     private fun handleChangingPassword(status: Resource<UserPassword>?) {
         when (status) {
-            is Resource.Error -> showLoading()
+            is Resource.Loading -> {
+                showLoading()
+            }
+
             is Resource.Success -> status.data?.let {
                 hideLoading()
                 viewModel.showToastMessage(resources.getString(R.string.find_password_done))
                 navigateToSignInFragment()
             }
 
-            is Resource.Loading -> {
-                hideLoading()
-            }
+            is Resource.Error -> hideLoading()
 
             null -> {}
         }

--- a/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordViewModel.kt
+++ b/app/src/main/java/org/cazait/ui/findaccount/findpassword/FindUserPasswordViewModel.kt
@@ -37,4 +37,8 @@ class FindUserPasswordViewModel @Inject constructor(private val userRepository: 
         if (errorMessage == null) return
         _showToast.value = SingleEvent(errorMessage)
     }
+
+    fun initViewModel() {
+        _changePasswordProcess.value = null
+    }
 }

--- a/app/src/main/java/org/cazait/ui/phoneverify/PhoneVerifyFragment.kt
+++ b/app/src/main/java/org/cazait/ui/phoneverify/PhoneVerifyFragment.kt
@@ -127,29 +127,6 @@ class PhoneVerifyFragment : BaseFragment<FragmentPhoneVerifyBinding, PhoneVerify
         }
     }
 
-    private fun handleUserData(status: Resource<FindPassUserData>?) {
-        when (status) {
-            is Resource.Loading -> {
-                showLoading()
-            }
-
-            is Resource.Success -> status.data?.let {
-                hideLoading()
-                viewModel.showToastMessage(it.message)
-                foundUserData = it
-                val phoneNumber = binding.etFindUserIdPhoneNumber.text.toString()
-                viewModel.sendVerificationCode(phoneNumber)
-            }
-
-            is Resource.Error -> {
-                hideLoading()
-                viewModel.showToastMessage(status.message)
-            }
-
-            null -> {}
-        }
-    }
-
     private fun handlePhone(status: Resource<VerificationCode>?) {
         when (status) {
             is Resource.Loading -> {
@@ -189,7 +166,10 @@ class PhoneVerifyFragment : BaseFragment<FragmentPhoneVerifyBinding, PhoneVerify
                     viewModel.findUserId(phoneNumber)
                 } else if (title == resources.getString(R.string.btn_find_password)) {
                     timer.cancel()
-                    navigateToFindUserPasswordFragment(navArgs.userUuid.toString(), foundUserData.userId)
+                    navigateToFindUserPasswordFragment(
+                        navArgs.userUuid.toString(),
+                        foundUserData.userId
+                    )
                 } else if (title == resources.getString(R.string.sign_up_sign_up)) {
                     timer.cancel()
                     navigateToSignUpFragment(phoneNumber)
@@ -205,7 +185,10 @@ class PhoneVerifyFragment : BaseFragment<FragmentPhoneVerifyBinding, PhoneVerify
                     viewModel.findUserId(phoneNumber)
                 } else if (title == resources.getString(R.string.btn_find_password)) {
                     timer.cancel()
-                    navigateToFindUserPasswordFragment(navArgs.userUuid.toString(), foundUserData.userId)
+                    navigateToFindUserPasswordFragment(
+                        navArgs.userUuid.toString(),
+                        foundUserData.userId
+                    )
                 } else if (title == resources.getString(R.string.sign_up_sign_up)) {
                     timer.cancel()
                     navigateToSignUpFragment(phoneNumber)
@@ -227,6 +210,30 @@ class PhoneVerifyFragment : BaseFragment<FragmentPhoneVerifyBinding, PhoneVerify
                 timer.cancel()
                 val foundUserId = status.data?.userId
                 navigateToFindUserIdFragment(foundUserId)
+            }
+
+            is Resource.Error -> {
+                hideLoading()
+                viewModel.showToastMessage(status.message)
+            }
+
+            null -> {}
+        }
+    }
+
+    private fun handleUserData(status: Resource<FindPassUserData>?) {
+        when (status) {
+            is Resource.Loading -> {
+                showLoading()
+            }
+
+            is Resource.Success -> status.data?.let {
+                hideLoading()
+                viewModel.showToastMessage(it.message)
+                foundUserData = it
+                Log.d("휴대폰 인증에서 받은 foundUserData", foundUserData.toString())
+                val phoneNumber = binding.etFindUserIdPhoneNumber.text.toString()
+                viewModel.sendVerificationCode(phoneNumber)
             }
 
             is Resource.Error -> {
@@ -280,7 +287,12 @@ class PhoneVerifyFragment : BaseFragment<FragmentPhoneVerifyBinding, PhoneVerify
     }
 
     private fun navigateToFindUserPasswordFragment(userUuid: String, userId: String) {
-        findNavController().navigate(PhoneVerifyFragmentDirections.actionPhoneVerifyFragmentToFindUserPasswordFragment(userUuid, userId))
+        findNavController().navigate(
+            PhoneVerifyFragmentDirections.actionPhoneVerifyFragmentToFindUserPasswordFragment(
+                userUuid,
+                userId
+            )
+        )
     }
 
     private fun observeToast(event: LiveData<SingleEvent<Any>>) {

--- a/app/src/main/res/layout/fragment_find_user_id.xml
+++ b/app/src/main/res/layout/fragment_find_user_id.xml
@@ -105,5 +105,18 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/btn_go_login" />
+
+        <com.airbnb.lottie.LottieAnimationView
+            android:id="@+id/lottie_find_id_result"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:lottie_autoPlay="true"
+            app:lottie_fileName="lottie_coffee.json"
+            app:lottie_loop="true" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 아이디 찾기 완료 후 '로그인 하기'와 '비밀번호 찾기' 버튼 중 '비밀번호 찾기' 클릭 시 기존 비밀번호 찾기 처럼 유저 ID DB 조회를 실행
- 조회 완료 후 FindPasswordFragment로 이동. 비밀번호 변경 가능
## 비밀번호 변경하는 2가지 방법
### SignInFragment에서
1. '비밀번호 찾기' 클릭 시 사용자 ID 확인
2. 확인 완료 되면 휴대폰 번호로 검증 + 인증번호 전송 및 확인
3. 확인이 완료되면 FindPasswordFragment로 이동
### 아이디 찾기 완료된 후
1. '비밀번호 찾기' 클릭 시 사용자 ID 확인이 자동으로 이루어짐.
2. 완료 시 바로 FindPasswordFragment로 이동

## 애매한 부분
- 아이디 찾기 후 비밀번호 찾기를 할 때에 [API 문서](https://polymorphismj.notion.site/polymorphismj/API-d493c2e6d793479e8a0ccbb94e32a280) 와는 다르게 진행되는데도 변경이 되는데 원래 의도된건가,..?